### PR TITLE
Fixed mixed values in sorting.

### DIFF
--- a/production/frontend/src/lib/sorting.js
+++ b/production/frontend/src/lib/sorting.js
@@ -36,10 +36,10 @@ export function sort_procedures(state, sortingMethod){
         const pi_1 = state.procedure_identifier.get(prod_1.series_description);
         const pi_2 = state.procedure_identifier.get(prod_2.series_description);
 
-        return pi_1.description > pi_2.description ? LESSER : GREATER;
+        return pi_1.description > pi_2.description ? GREATER : LESSER;
       case PROCEDURE_SORTING.TRACER:
-        if (prod_1.tracer === null) return LESSER
-        if (prod_2.tracer === null) return GREATER
+        if (prod_1.tracer === null) return GREATER
+        if (prod_2.tracer === null) return LESSER
         return prod_1.tracer - prod_2.tracer;
       case PROCEDURE_SORTING.UNITS:
         return prod_1.tracer_units - prod_2.tracer_units;

--- a/production/frontend/src/tests/lib/formatting.test.js
+++ b/production/frontend/src/tests/lib/formatting.test.js
@@ -120,8 +120,16 @@ describe("FormatDateStr tests", () => {
 describe("formatTimeStamp Tests", () => {
   const testDate = new Date(2020, 10, 11, 8, 30);
   it("is Valid", () => {
-    expect(formatTimeStamp(testDate)).toEqual("08:30");
-    expect(formatTimeStamp("2020-10-11T08:30")).toEqual("08:30");
+    try { //to account for either danish or english system clock.
+      expect(formatTimeStamp(testDate)).toEqual("08:30"); //english
+    } catch {
+      expect(formatTimeStamp(testDate)).toEqual("08.30"); //danish
+    }
+    try{
+      expect(formatTimeStamp("2020-10-11T08:30")).toEqual("08:30"); //english
+    } catch {
+      expect(formatTimeStamp("2020-10-11T08:30")).toEqual("08.30"); //danish
+    }
   });
 
   it("is unknown", () =>{


### PR DESCRIPTION
Fixed a mix-up in the code that turned the sorting around for procedures, (I guess that's why we have tests)
along with adding a try-catch to one of the formatting tests, as my danish system clock formats date-times with dot (.) while English systems use colon (:) it now allows both for testing, I'm unsure if this difference has any affect on the program itself.